### PR TITLE
Виправлене посилання на Sequences

### DIFF
--- a/007.asc
+++ b/007.asc
@@ -32,7 +32,7 @@
 Так, вона справжня. Якщо ви подивитеся в мій профіль, то побачите посилання на 
 один науковий сайт, де ви можете навчитися взагалі-то всьому, що знає
 Гаррі Джеймс Поттер-Еванс-Веррес, __і навіть більше__. (Примітка перекладача: 
-гадаю, йдеться про https://wiki.lesswrong.com/wiki/Sequences.)
+гадаю, йдеться про https://wiki.lesswrong.com/wiki/Sequences[https://wiki.lesswrong.com/wiki/Sequences].)
 
 // 719
 //Thank you very much to __all __my reviewers. (Especially Darkandus on


### PR DESCRIPTION
Перед тим, як додав крапку, посилання генерувалося правильно, проте треба крапку. Крапка й пробіл — нема проблем, проте пробіл зайвий.

Ну, власне.